### PR TITLE
Permite especificar dados da nota fiscal.

### DIFF
--- a/pysigep/templates/PLP.xml
+++ b/pysigep/templates/PLP.xml
@@ -52,8 +52,8 @@
             <cep_destinatario><![CDATA[{{ objeto.cep_destinatario }}]]></cep_destinatario>
             <codigo_usuario_postal />
             <centro_custo_cliente />
-            <numero_nota_fiscal />
-            <serie_nota_fiscal />
+            <numero_nota_fiscal>{{ objeto.numero_nota_fiscal }}</numero_nota_fiscal>
+            <serie_nota_fiscal>{{ objeto.serie_nota_fiscal }}</serie_nota_fiscal>
             <valor_nota_fiscal />
             <natureza_nota_fiscal />
             <descricao_objeto><![CDATA[{{ objeto.descricao_objeto }}]]></descricao_objeto>

--- a/test/sigep_test/fecha_plp_servicos_test.py
+++ b/test/sigep_test/fecha_plp_servicos_test.py
@@ -46,6 +46,8 @@ class TestFechaPlpServicos(TestCase):
                 'cidade_destinatario': '',
                 'uf_destinatario': '',
                 'cep_destinatario': '',
+                'numero_nota_fiscal': '',
+                'serie_nota_fiscal': '',
                 'descricao_objeto': '',
                 'valor_a_cobrar': '',
                 'valor_declarado': '',


### PR DESCRIPTION
De acordo com a documentação, número e série da nota são obrigatórios
para PAC, por isso, abri a possibilidade de especificá-los.