### PR TITLE
Adiciona método para consultar PLP já gerada.

### DIFF
--- a/pysigep/sigep/__init__.py
+++ b/pysigep/sigep/__init__.py
@@ -137,3 +137,11 @@ def fecha_plp_servicos(**kwargs):
     kwargs["xml"] = '<?xml version="1.0" encoding="ISO-8859-1" ?>' + xml
     return send("FechaPlpVariosServicos.xml", 'fechaPlpVariosServicosResponse',
                 API, url, encoding="ISO-8859-1", **kwargs)
+
+
+def solicita_xml_plp(**kwargs):
+    _valida('solicita_xml_plp', API, kwargs)
+    url = _url(kwargs['ambiente'], API)
+    path = 'SolicitaXmlPlp.xml'
+    return send(path, 'solicitaXmlPlpResponse',
+                API, url, **kwargs)

--- a/pysigep/templates/SolicitaXmlPlp.xml
+++ b/pysigep/templates/SolicitaXmlPlp.xml
@@ -1,0 +1,11 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:cli="http://cliente.bean.master.sigep.bsb.correios.com.br/">
+    <soapenv:Header/>
+    <soapenv:Body>
+        <cli:solicitaXmlPlp>
+            <idPlpMaster>{{ idPlpMaster }}</idPlpMaster>
+            <usuario>{{ usuario }}</usuario>
+            <senha>{{ senha }}</senha>
+        </cli:solicitaXmlPlp>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/test/sigep_test/solicita_xml_plp_test.py
+++ b/test/sigep_test/solicita_xml_plp_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# #############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Michell Stuttgart
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+###############################################################################
+
+from unittest import TestCase
+
+from pysigep.sigep import solicita_xml_plp
+
+
+class TestVerificaDisponibilidadeServico(TestCase):
+
+    def setUp(self):
+        self.kwargs = {
+            'idPlpMaster': '111111',
+            'usuario': 'sigep',
+            'senha': 'n5f9t8',
+        }
+
+    def test_solicita_xml_plp_falha_sem_ambiente(self):
+        with self.assertRaises(Exception):
+            solicita_xml_plp(**kwargs)
+
+    def test_solicita_xml_plp_retorna_xml(self):
+        self.kwargs['ambiente'] = 1
+        resposta = solicita_xml_plp(**self.kwargs)
+        print resposta


### PR DESCRIPTION
Por hora só retorno o XML devolvido pelos correios (em texto puro),
deixo por conta de quem vai usar transformar o XML em um objeto se
necessário.