### PR TITLE
Add missing fonts to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include README.md
 include pysigep/templates/*.xml
 include pysigep/correios/data/layout.xsd
+include pysigep/correios/data/fonts/*.ttf


### PR DESCRIPTION
Those fonts are missing, so correios.sign_chancela raises an exception. The fix is very simple.